### PR TITLE
IResearch address_table tests

### DIFF
--- a/core/formats/columnstore2.hpp
+++ b/core/formats/columnstore2.hpp
@@ -103,7 +103,7 @@ public:
       return true;
     }
 
-    bool pop_back() {
+    bool pop_back() noexcept {
       IRS_ASSERT(offsets_ < offset_);
       if (!(offsets_ < offset_))
         return false;

--- a/core/resource_manager.hpp
+++ b/core/resource_manager.hpp
@@ -83,7 +83,7 @@ protected:
 public:
   virtual ~IResearchMemoryManager() = default;
 
-  virtual void Increase([[maybe_unused]] uint64_t value) override {
+  virtual void Increase([[maybe_unused]] size_t value) override {
 
     IRS_ASSERT(this != &kForbidden);
     IRS_ASSERT(value >= 0);
@@ -105,7 +105,7 @@ public:
     }
   }
 
-  virtual void Decrease([[maybe_unused]] uint64_t value) noexcept override {
+  virtual void Decrease([[maybe_unused]] size_t value) noexcept override {
     IRS_ASSERT(this != &kForbidden);
     IRS_ASSERT(value >= 0);
     _current.fetch_sub(value, std::memory_order_relaxed);
@@ -113,7 +113,7 @@ public:
 
   //  NOTE: IResearchFeature owns and manages this memory limit.
   //  That is why this method should only be used by IResearchFeature.
-  virtual void SetMemoryLimit(uint64_t memoryLimit) {
+  virtual void SetMemoryLimit(size_t memoryLimit) {
     _memoryLimit.store(memoryLimit);
   }
 
@@ -122,8 +122,8 @@ private:
   //  During IResearchFeature::validateOptions() this limit is set to a
   //  percentage of either the total available physical memory or the value
   //  of ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY envvar if specified.
-  std::atomic<std::uint64_t> _memoryLimit = { 0 };
-  std::atomic<std::uint64_t> _current = { 0 };
+  std::atomic<size_t> _memoryLimit = { 0 };
+  std::atomic<size_t> _current = { 0 };
 
   //  Singleton
   static inline std::shared_ptr<IResearchMemoryManager> _instance;

--- a/core/resource_manager.hpp
+++ b/core/resource_manager.hpp
@@ -88,13 +88,13 @@ public:
     IRS_ASSERT(this != &kForbidden);
     IRS_ASSERT(value >= 0);
 
-    if (0 == _memoryLimit) {
+    if (_memoryLimit == 0) {
       // since we have no limit, we can simply use fetch-add for the increment
       _current.fetch_add(value, std::memory_order_relaxed);
     } else {
       // we only want to perform the update if we don't exceed the limit!
-      std::uint64_t cur = _current.load(std::memory_order_relaxed);
-      std::uint64_t next;
+      size_t cur = _current.load(std::memory_order_relaxed);
+      size_t next;
       do {
         next = cur + value;
         if (IRS_UNLIKELY(next > _memoryLimit.load(std::memory_order_relaxed))) {
@@ -115,6 +115,10 @@ public:
   //  That is why this method should only be used by IResearchFeature.
   virtual void SetMemoryLimit(size_t memoryLimit) {
     _memoryLimit.store(memoryLimit);
+  }
+
+  size_t getCurrentUsage() {
+    return _current.load(std::memory_order_relaxed);
   }
 
 private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(IReSearch_tests_sources
   ./formats/formats_tests.cpp
   ./formats/formats_test_case_base.cpp
   ./formats/skip_list_test.cpp
+  ./formats/address_table_tests.cpp
   ./store/directory_test_case.cpp
   ./store/caching_directory_test.cpp
   ./store/directory_cleaner_tests.cpp

--- a/tests/formats/address_table_tests.cpp
+++ b/tests/formats/address_table_tests.cpp
@@ -1,0 +1,181 @@
+
+#include <iostream>
+#include "formats/columnstore2.hpp"
+#include "resource_manager.hpp"
+#include <gtest/gtest.h>
+
+using irs::columnstore2::column;
+
+namespace {
+
+    class address_table_tests : public ::testing::Test {
+        public:
+            address_table_tests() { }
+
+            void SetUp() override {
+            }
+
+            void TearDown() override {}
+
+        public:
+            irs::ManagedTypedAllocator<uint64_t> alloc;
+    };
+}
+
+TEST_F(address_table_tests, smoke_test) {
+
+    column::address_table addr_table(alloc);
+
+    ASSERT_EQ(0, addr_table.size());
+
+    //  push
+    ASSERT_TRUE(addr_table.push_back(1));
+    ASSERT_EQ(1, addr_table.size());
+
+    //  pop
+    ASSERT_TRUE(addr_table.pop_back());
+    ASSERT_EQ(0, addr_table.size());
+
+    //  full
+    for (uint64_t i = 0; i < column::kBlockSize; i++) {
+        ASSERT_TRUE(addr_table.push_back(i));
+    }
+    ASSERT_EQ(addr_table.size(), column::kBlockSize);
+    ASSERT_TRUE(addr_table.full());
+
+    //  reset
+    addr_table.reset();
+    ASSERT_TRUE(addr_table.empty());
+}
+
+//  pop when empty
+TEST_F(address_table_tests, pop_when_empty) {
+
+    column::address_table addr_table(alloc);
+    ASSERT_TRUE(addr_table.empty());
+    ASSERT_FALSE(addr_table.pop_back());
+}
+
+//  push when full
+TEST_F(address_table_tests, push_when_full) {
+
+    column::address_table addr_table(alloc);
+
+    ASSERT_TRUE(addr_table.empty());
+
+    for (uint64_t i = 0; i < column::kBlockSize; i++) {
+        ASSERT_TRUE(addr_table.push_back(i));
+    }
+
+    ASSERT_EQ(addr_table.size(), column::kBlockSize);
+    ASSERT_FALSE(addr_table.push_back(2));
+
+    ASSERT_TRUE(addr_table.pop_back());
+    ASSERT_TRUE(addr_table.push_back(2));
+}
+
+//  push and verify data
+TEST_F(address_table_tests, verify_data) {
+
+    column::address_table addr_table(alloc);
+
+    for (uint64_t i = 0; i < 200; i++) {
+        ASSERT_TRUE(addr_table.push_back(i));
+    }
+
+    ASSERT_EQ(addr_table.size(), 200);
+
+    auto curr = addr_table.current();
+    auto begin = addr_table.begin();
+
+    uint64_t data { 199 };
+    while (curr != begin) {
+        --curr;
+        ASSERT_EQ(*curr, data--);
+    }
+}
+
+//  write using current ptr
+TEST_F(address_table_tests, write_using_current_ptr) {
+
+    column::address_table addr_table(alloc);
+
+    //  add data via push_back.
+    auto data = 0;
+    for (uint64_t i = 0; i < 60; i++) {
+        ASSERT_TRUE(addr_table.push_back(data++));
+    }
+
+    //  add data via current() ptr.
+    //  column::flush_block() uses address_table
+    //  in this way.
+    auto curr = addr_table.current();
+    uint64_t addr_table_size = 40900;
+    auto end = curr + addr_table_size;
+
+    while (curr != end) {
+        *curr++ = data++;
+    }
+
+    //  size is updated only when adding data
+    //  via push_back().
+    ASSERT_EQ(addr_table.size(), 60);
+
+    auto begin = addr_table.begin();
+    for (uint64_t i = 0; i < 40960; i++) {
+        ASSERT_EQ(*begin++, i);
+    }
+}
+
+//  size arithmetic
+TEST_F(address_table_tests, begin_current_end) {
+
+    column::address_table addr_table(alloc);
+
+    ASSERT_EQ(addr_table.size(), 0);
+    ASSERT_TRUE(addr_table.push_back(45));
+    ASSERT_EQ(addr_table.size(), 1);
+
+    ASSERT_EQ(addr_table.current(), addr_table.begin() + addr_table.size());
+}
+
+//  max size allowed
+TEST_F(address_table_tests, max_size_allowed) {
+
+    column::address_table addr_table(alloc);
+
+    //  end() always points to begin() + kBlockSize
+    //  coz address_table pre-allocates memory to
+    //  accommodate kBlockSize elements.
+    ASSERT_EQ(addr_table.size(), 0);
+    ASSERT_EQ(addr_table.end(), addr_table.begin() + column::kBlockSize);
+    ASSERT_EQ(addr_table.current(), addr_table.begin() + 0);
+
+    for (uint64_t i = 0; i < 1234; i++) {
+        ASSERT_TRUE(addr_table.push_back(i));
+    }
+
+    ASSERT_EQ(addr_table.end(), addr_table.begin() + column::kBlockSize);
+    ASSERT_EQ(addr_table.current(), addr_table.begin() + 1234);
+}
+
+//  full
+TEST_F(address_table_tests, empty_full_and_reset) {
+
+    column::address_table addr_table(alloc);
+
+    ASSERT_FALSE(addr_table.full());
+    for (uint64_t i = 0; i < column::kBlockSize; i++) {
+        ASSERT_TRUE(addr_table.push_back(i));
+    }
+    ASSERT_TRUE(addr_table.full());
+
+    addr_table.pop_back();
+    ASSERT_FALSE(addr_table.full());
+    ASSERT_EQ(addr_table.current() + 1, addr_table.end());
+
+    addr_table.reset();
+    ASSERT_FALSE(addr_table.full());
+    ASSERT_EQ(addr_table.current(), addr_table.begin());
+    ASSERT_EQ(addr_table.size(), 0);
+}


### PR DESCRIPTION
This is a precursor to fixing the over-allocation of memory to address_table per column.

Few things to remember with regards to the existing design of `class address_table`.:
- `address_table::offset_` points to the location in the array where the next item will be written when `push_back()` is called.
- `address_table::current()` returns a pointer to current and the user can go on writing to / advancing their pointer. Elements added to the address_table in such manner do not affect the results of the `address_table::size()` function. `size()` only works well when we use `push_back / pop_back` methods.
- The above behavior applies to the `address_table::back()` method as well.

Plz check if there's a need for more tests to ensure all of the above behavior is tested. Only when we have enough tests to verify the current behavior of `address_table` can I create the PR for the new design with the fix.

Jenkins build:
https://jenkins.arangodb.biz/view/PR/job/iresearch-pr/1062/