### PR TITLE
Fixed over-consumption / wastage of memory in IResearch address_table

### DIFF
--- a/core/formats/columnstore2.hpp
+++ b/core/formats/columnstore2.hpp
@@ -106,7 +106,7 @@ public:
         return false;
 
       if (offsets_.size() <= static_cast<decltype(offsets_)::size_type>(current_pos_))
-        offsets_.resize(current_pos_ + 1);
+        offsets_.resize(current_pos_ * 2 + 1);
 
       offsets_[current_pos_++] = offset;
       return true;
@@ -153,7 +153,6 @@ public:
     //  where new data will be added.
     //  Call grow_size() to allocate space before using current()
     uint64_t* current() noexcept { return &offsets_[current_pos_]; }
-    uint64_t* end() noexcept { return &offsets_[current_pos_]; }
 
    private:
     std::vector<uint64_t, ManagedTypedAllocator<uint64_t>> offsets_;


### PR DESCRIPTION
This fix changes the underlying implementation of `class address_table`. Previously the class pre-allocated a large chunk of contiguous memory and allowed users to access that memory directly through raw pointers.
It operated on the assumption that there will always be memory and allowed users to freely dereference it using pointers without performing out of bounds checks.

The new implementation also allows users to dereference underlying memory through raw pointers but it expects users to grow the memory (`grow_size()`) before they start dereferencing it. Memory allocation is done on demand and we've greatly reduced the memory footprint of this class. Reallocation of memory upon need means previous iterators / pointers will become invalid.

https://jenkins.arangodb.biz/view/PR/job/iresearch-pr/1066/