### PR TITLE
Set new defaults for the 'tier' consdolidation policy

### DIFF
--- a/core/utils/index_utils.hpp
+++ b/core/utils/index_utils.hpp
@@ -70,13 +70,13 @@ ConsolidationPolicy MakePolicy(const ConsolidateDocsFill& options);
 
 struct ConsolidateTier {
   // minimum allowed number of segments to consolidate at once
-  size_t min_segments = 1;
+  size_t min_segments = 50;
   // maximum allowed number of segments to consolidate at once
-  size_t max_segments = 10;
+  size_t max_segments = 200;
   // maxinum allowed size of all consolidated segments
-  size_t max_segments_bytes = size_t(5) * (1 << 30);
+  size_t max_segments_bytes = size_t(8) * (1 << 30);
   // treat all smaller segments as equal for consolidation selection
-  size_t floor_segment_bytes = size_t(2) * (1 << 20);
+  size_t floor_segment_bytes = size_t(24) * (1 << 20);
   // filter out candidates with score less than min_score
   double_t min_score = 0.;
 };


### PR DESCRIPTION
Defaults for the "tier" consolidation policy have caused many index creations to drive file descriptors into limits on cloud volumes. There is no impact on performance. Only consolidations are done less regularly and with more data.

- [x] https://jenkins.arangodb.biz/view/PR/job/iresearch-pr/1068/