### PR TITLE
[chore] make compile with clang21

### DIFF
--- a/external/frozen/include/frozen/string.h
+++ b/external/frozen/include/frozen/string.h
@@ -110,24 +110,24 @@ using u8string = basic_string<char8_t>;
 
 namespace string_literals {
 
-constexpr string operator"" _s(const char *data, std::size_t size) {
+constexpr string operator""_s(const char *data, std::size_t size) {
   return {data, size};
 }
 
-constexpr wstring operator"" _s(const wchar_t *data, std::size_t size) {
+constexpr wstring operator""_s(const wchar_t *data, std::size_t size) {
   return {data, size};
 }
 
-constexpr u16string operator"" _s(const char16_t *data, std::size_t size) {
+constexpr u16string operator""_s(const char16_t *data, std::size_t size) {
   return {data, size};
 }
 
-constexpr u32string operator"" _s(const char32_t *data, std::size_t size) {
+constexpr u32string operator""_s(const char32_t *data, std::size_t size) {
   return {data, size};
 }
 
 #ifdef FROZEN_LETITGO_HAS_CHAR8T
-constexpr u8string operator"" _s(const char8_t *data, std::size_t size) {
+constexpr u8string operator""_s(const char8_t *data, std::size_t size) {
   return {data, size};
 }
 #endif


### PR DESCRIPTION
This makes arangodb compile with clang21;

Since `frozen` seems to be an external dependency it might be better to update it; alas the change is small, it removes a bit of whitespace.

An alternative fix owuld be to disable the warning that leads to the error.

