### PR TITLE
Migrate to new consolidation options

### DIFF
--- a/core/utils/index_utils.hpp
+++ b/core/utils/index_utils.hpp
@@ -111,7 +111,6 @@ namespace tier {
       } while (itr++ != end);
 
       skew = static_cast<double>(attrs.byteSize) / mergeBytes;
-      mergeScore = skew;
     }
 
     //  It is the caller's responsibility to ensure that
@@ -135,7 +134,6 @@ namespace tier {
 
       mergeBytes -= remSegAttrs.byteSize;
       skew = static_cast<double>(lastSegAttrs.byteSize) / mergeBytes;
-      mergeScore = skew;
 
       return true;
     }
@@ -157,7 +155,6 @@ namespace tier {
 
       mergeBytes += attrs.byteSize;
       skew = static_cast<double>(attrs.byteSize) / mergeBytes;
-      mergeScore = skew;
 
       return true;
     }
@@ -167,7 +164,6 @@ namespace tier {
 
     size_t mergeBytes { 0 };
     double skew { 0.0 };
-    double mergeScore { 0.0 };
     bool initialized { false };
 
     range_t segments;
@@ -315,8 +311,8 @@ namespace tier {
             continue;
           }
 
-          if (candidate.mergeScore <= maxSkewThreshold &&
-              (!best.initialized || best.mergeScore > candidate.mergeScore))
+          if (candidate.skew <= maxSkewThreshold &&
+              (!best.initialized || best.skew > candidate.skew))
             best = candidate;
 
           if (candidate.last() == (segments.end() - 1))

--- a/core/utils/index_utils.hpp
+++ b/core/utils/index_utils.hpp
@@ -368,8 +368,6 @@ struct ConsolidateDocsFill {
 
 ConsolidationPolicy MakePolicy(const ConsolidateDocsFill& options);
 
-//  [TODO] Currently unused as the new algorithm uses a different
-//  approach. Only max_segments_bytes is in use.
 struct ConsolidateTier {
   // maxinum allowed size of all consolidated segments
   size_t max_segments_bytes = size_t(8) * (1 << 30);


### PR DESCRIPTION
- Added maxSkewThreshold and minDeletionRatio to irs::index_utils::ConsolidateTier
- Updated unit tests
- Removed the redundant ConsolidationCandidate::mergeScore property


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `max_skew_threshold` and `min_deletion_ratio` to `ConsolidateTier`, refactor cleanup/merge selection to use them, remove obsolete score/config, and update tests.
> 
> - **Core (index_utils)**:
>   - Add `ConsolidateTier` options: `max_skew_threshold` (merge) and `min_deletion_ratio` (cleanup); remove reliance on previous min/max segments, floor size, and score config.
>   - Update `MakePolicy(const ConsolidateTier&)` to pass new thresholds, alternate cleanup/merge, and select candidates accordingly.
>   - Change `tier::findBestCleanupCandidate(...)` to accept `minDeletionRatio`, sort by deletion ratio, and gate by combined deletion ratio.
>   - Change `tier::findBestConsolidationCandidate(...)` to accept `maxSkewThreshold`, require window size ≥ 2, and compare `candidate.skew` against threshold (no `ConsolidationConfig`).
>   - Simplify `tier::ConsolidationCandidate`: remove `mergeScore`; use `skew` only.
>   - Remove `tier::ConsolidationConfig` and related uses.
> - **Tests**:
>   - Update all calls to new function signatures and thresholds; add local `constexpr` for `minDeletionPercentage`/`maxSkewThreshold`.
>   - Adjust expectations where skew threshold or cleanup ratio alters candidate sets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acd7ec61766125d7f8636600b068c44f308152f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->